### PR TITLE
Add vscode workspace setting to force tab character to be used

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.insertSpaces": false
+}


### PR DESCRIPTION
This will force visual studio code to use tab characters instead of spaces when working in this directory.