### PR TITLE
Added "ready" member to PluginManager and "projectOpen/projectClose" events

### DIFF
--- a/src/gml/Project.hx
+++ b/src/gml/Project.hx
@@ -15,6 +15,8 @@ import parsers.GmlSeeker;
 import raw.GmlLoader;
 import tools.Dictionary;
 import gml.GmlAPI;
+import plugins.PluginEvents;
+import plugins.PluginManager;
 import ace.AceWrap;
 import gmx.*;
 import yy.*;
@@ -236,8 +238,15 @@ import ui.treeview.TreeView;
 		if (current != null) current.close();
 		current = new Project(path);
 		if (path != "") ui.RecentProjects.add(current.path != null ? current.path : path);
+		if (PluginManager.ready == true && current.version != 0) {
+			PluginEvents.projectOpen({project:null});
+		}
+		
 	}
 	public function close() {
+		if (current.version != 0) {
+			PluginEvents.projectClose({project:current});
+		}
 		TreeView.saveOpen();
 		var tabPaths:Array<String> = [];
 		for (_tab in ChromeTabs.element.querySelectorAll(".chrome-tab")) try {

--- a/src/plugins/PluginEvents.hx
+++ b/src/plugins/PluginEvents.hx
@@ -1,5 +1,6 @@
 package plugins;
 import gml.file.GmlFile;
+import gml.Project;
 import ui.ChromeTabs;
 import ui.ChromeTabs.ChromeTabsImpl;
 
@@ -22,6 +23,16 @@ extern class PluginEvents {
 	 * Dispatches when a new file is opened and ready to go.
 	 */
 	static function fileOpen(e:{file:GmlFile}):Void;
+
+	/**
+	 * Dispatches when a new project is opened and ready to go.
+	 */
+	static function projectOpen(e:{project:Project}):Void;
+
+	/**
+	 * Dispatches when the project is closed or a new project is opened
+	 */
+	static function projectClose(e:{project:Project}):Void;
 	
 	/**
 	 * Dispatches when active file (read: tab) changes

--- a/src/plugins/PluginManager.hx
+++ b/src/plugins/PluginManager.hx
@@ -109,6 +109,8 @@ class PluginManager {
 		});
 	}
 	
+	// Set to true whenever manager is initalised
+	public static var ready:Bool = false;
 	public static function init() {
 		try {
 			Type.resolveClass("Main");
@@ -150,6 +152,7 @@ class PluginManager {
 		];
 		//
 		for (name in list) load(name);
+		ready = true;
 	}
 }
 typedef PluginCallback = (error:Null<Error>)->Void;


### PR DESCRIPTION
"ready" member was added as a workaround for plugin events being called too early, plugin events added for capturing projects being opened and closed