### PR TITLE
Fixes macOS builds falsely detecting ProcessSerialNumber

### DIFF
--- a/src/ui/FileDrag.hx
+++ b/src/ui/FileDrag.hx
@@ -69,7 +69,9 @@ class FileDrag {
 					yy.YyZip.open(name, bytes);
 				}
 			};
-			default: decline();
+			default: {
+				if (path.substr(0, 4) != "-psn") decline();
+			};
 		}
 	}
 	public static function init() {


### PR DESCRIPTION
Running the packaged version of GMEdit on macOS will display an error message upon opening it because it detects the "-psn" argument and tries to interpret it as a file drop operation. This code just checks if the first 4 characters of the argument are not equal to `-psn` to decline it.