### PR TITLE
Fix off by one error with F1|F12 command

### DIFF
--- a/src/ace/AceCommands.hx
+++ b/src/ace/AceCommands.hx
@@ -107,6 +107,7 @@ import ui.CommandPalette;
 			bindKey: "F1|F12",
 			exec: function(editor:AceWrap) {
 				var pos = editor.getCursorPosition();
+				pos.column += 1;
 				var tk = editor.session.getTokenAtPos(pos);
 				ui.OpenDeclaration.proc(editor.session, pos, tk);
 			}


### PR DESCRIPTION
F1 or F12 didn't work when cursor was on first char a function name, so I just moved the cursor over 1 column.