### PR TITLE
Sprite Frame Open Externally

### DIFF
--- a/src/editors/EditSprite.hx
+++ b/src/editors/EditSprite.hx
@@ -19,6 +19,7 @@ using tools.HtmlTools;
 import yy.YySprite;
 import Main.document;
 import Main.window;
+import electron.Shell;
 
 /**
  * This is a big mess as for something that's just an image strip viewer.
@@ -264,6 +265,9 @@ class EditSprite extends Editor {
 			frame.onclick = function(_) {
 				currentFrame = index;
 				setCurrentFrameElement(index, frame);
+			}
+			frame.ondblclick = function(_) {
+				Shell.openExternal(url);
 			};
 			frames.appendChild(frame);
 		}


### PR DESCRIPTION
Added the ability to open a frame of a sprite externally by double-clicking it.