### PR TITLE
Fix Ctrl+T for indented functions

### DIFF
--- a/src/file/kind/KGml.hx
+++ b/src/file/kind/KGml.hx
@@ -103,7 +103,7 @@ class KGml extends KCode {
 		var row = 0, col = 0;
 		var i:Int, s:String;
 		if (nav.def != null) {
-			var rxDef = new RegExp("^(#define|#event|#moment|#target|function)[ \t]+" + NativeString.escapeRx(nav.def) + "\\b");
+			var rxDef = new RegExp("^[ \t]*(#define|#event|#moment|#target|function)[ \t]+" + NativeString.escapeRx(nav.def) + "\\b");
 			i = 0;
 			while (i < len) {
 				s = session.getLine(i);


### PR DESCRIPTION
Simply adds whitespace to the beginning of the regex for navigating to a function.
Addresses this issue: https://github.com/YellowAfterlife/GMEdit/issues/252 

The only edge case i've found with using a regex is if you have a weird multiline macro, but that's not a worry of mine.
```
#macro test 1+1 \
function hello_world
```